### PR TITLE
Add full RSS support for blog

### DIFF
--- a/src/components/blog/RssLink.astro
+++ b/src/components/blog/RssLink.astro
@@ -1,0 +1,21 @@
+---
+import { Icon } from 'astro-icon/components';
+import { getAsset } from '~/utils/permalinks';
+
+export interface Props {
+  href: string;
+  label?: string;
+}
+
+const { href, label = 'Subscribe via RSS' } = Astro.props;
+---
+
+<div class="flex justify-center mb-8">
+  <a
+    href={getAsset(href)}
+    class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-orange-50 text-orange-700 hover:bg-orange-100 dark:bg-orange-900/30 dark:text-orange-300 dark:hover:bg-orange-900/50 text-sm font-medium transition-colors"
+  >
+    <Icon name="tabler:rss" class="w-4 h-4" />
+    {label}
+  </a>
+</div>

--- a/src/components/common/CommonMeta.astro
+++ b/src/components/common/CommonMeta.astro
@@ -13,5 +13,5 @@ const { rssFeed } = Astro.props;
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <link rel="sitemap" href={getAsset('/sitemap-index.xml')} />
-<link rel="alternate" type="application/rss+xml" title={`Blog — ${SITE.name}`} href={getAsset('/rss.xml')} />
+<link rel="alternate" type="application/rss+xml" title={`${SITE.name} Blog`} href={getAsset('/rss.xml')} />
 {rssFeed && <link rel="alternate" type="application/rss+xml" title={rssFeed.title} href={rssFeed.href} />}

--- a/src/components/common/CommonMeta.astro
+++ b/src/components/common/CommonMeta.astro
@@ -13,5 +13,5 @@ const { rssFeed } = Astro.props;
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <link rel="sitemap" href={getAsset('/sitemap-index.xml')} />
-<link rel="alternate" type="application/rss+xml" title={`${SITE.name} Blog`} href={getAsset('/rss.xml')} />
+<link rel="alternate" type="application/rss+xml" title={`Blog — ${SITE.name}`} href={getAsset('/rss.xml')} />
 {rssFeed && <link rel="alternate" type="application/rss+xml" title={rssFeed.title} href={rssFeed.href} />}

--- a/src/components/common/CommonMeta.astro
+++ b/src/components/common/CommonMeta.astro
@@ -1,8 +1,17 @@
 ---
+import { SITE } from 'astrowind:config';
 import { getAsset } from '~/utils/permalinks';
+
+export interface Props {
+  rssFeed?: { href: string; title: string };
+}
+
+const { rssFeed } = Astro.props;
 ---
 
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <link rel="sitemap" href={getAsset('/sitemap-index.xml')} />
+<link rel="alternate" type="application/rss+xml" title={`${SITE.name} Blog`} href={getAsset('/rss.xml')} />
+{rssFeed && <link rel="alternate" type="application/rss+xml" title={rssFeed.title} href={rssFeed.href} />}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,16 +21,17 @@ import type { MetaData as MetaDataType } from '~/types';
 
 export interface Props {
   metadata?: MetaDataType;
+  rssFeed?: { href: string; title: string };
 }
 
-const { metadata = {} } = Astro.props;
+const { metadata = {}, rssFeed } = Astro.props;
 const { language, textDirection } = I18N;
 ---
 
 <!doctype html>
 <html lang={language} dir={textDirection} class="text-[15px]">
   <head>
-    <CommonMeta />
+    <CommonMeta rssFeed={rssFeed} />
     <Favicons />
     <CustomStyles />
     <ApplyColorMode />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -13,9 +13,10 @@ import type { MetaData } from '~/types';
 export interface Props {
   metadata?: MetaData;
   editFile?: string;
+  rssFeed?: { href: string; title: string };
 }
 
-const { metadata, editFile } = Astro.props;
+const { metadata, editFile, rssFeed } = Astro.props;
 
 // Construct GitHub edit URL
 const GITHUB_REPO = 'https://github.com/mage-os/mage-os-org/tree/main';
@@ -60,7 +61,7 @@ function getEditUrl(): string | undefined {
 const editUrl = getEditUrl();
 ---
 
-<Layout metadata={metadata}>
+<Layout metadata={metadata} rssFeed={rssFeed}>
   <slot name="announcement">
     <Announcement />
   </slot>

--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -7,6 +7,7 @@ import BlogList from '~/components/blog/List.astro';
 import Headline from '~/components/blog/Headline.astro';
 import Pagination from '~/components/blog/Pagination.astro';
 import Button from '~/components/ui/Button.astro';
+import RssLink from '~/components/blog/RssLink.astro';
 
 import { blogListRobots, getStaticPathsBlogList, getPostsByCategory } from '~/utils/blog';
 import { getPermalink } from '~/utils/permalinks';
@@ -51,6 +52,8 @@ const metadata = {
 <Layout metadata={metadata}>
   <section class="px-4 sm:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-7xl">
     <Headline subtitle="News, releases, tutorials, and community updates from the Mage-OS project"> The Blog </Headline>
+
+    <RssLink href="/rss.xml" />
 
     {
       currentPage === 1 ? (

--- a/src/pages/[...blog]/[category]/[...page].astro
+++ b/src/pages/[...blog]/[category]/[...page].astro
@@ -29,7 +29,7 @@ const metadata = {
 };
 
 const rssHref = `/rss/category/${category.slug}.xml`;
-const rssFeed = { href: rssHref, title: `${category.title} — Mage-OS` };
+const rssFeed = { href: rssHref, title: `Mage-OS ${category.title}` };
 ---
 
 <Layout metadata={metadata} rssFeed={rssFeed}>

--- a/src/pages/[...blog]/[category]/[...page].astro
+++ b/src/pages/[...blog]/[category]/[...page].astro
@@ -29,7 +29,7 @@ const metadata = {
 };
 
 const rssHref = `/rss/category/${category.slug}.xml`;
-const rssFeed = { href: rssHref, title: `Mage-OS Blog — ${category.title}` };
+const rssFeed = { href: rssHref, title: `${category.title} — Mage-OS` };
 ---
 
 <Layout metadata={metadata} rssFeed={rssFeed}>

--- a/src/pages/[...blog]/[category]/[...page].astro
+++ b/src/pages/[...blog]/[category]/[...page].astro
@@ -6,6 +6,7 @@ import Layout from '~/layouts/PageLayout.astro';
 import BlogList from '~/components/blog/List.astro';
 import Headline from '~/components/blog/Headline.astro';
 import Pagination from '~/components/blog/Pagination.astro';
+import RssLink from '~/components/blog/RssLink.astro';
 
 export const prerender = true;
 
@@ -26,11 +27,15 @@ const metadata = {
     follow: blogCategoryRobots?.follow,
   },
 };
+
+const rssHref = `/rss/category/${category.slug}.xml`;
+const rssFeed = { href: rssHref, title: `Mage-OS Blog — ${category.title}` };
 ---
 
-<Layout metadata={metadata}>
+<Layout metadata={metadata} rssFeed={rssFeed}>
   <section class="px-4 md:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
     <Headline>{category.title}</Headline>
+    <RssLink href={rssHref} label={`Subscribe to ${category.title}`} />
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
   </section>

--- a/src/pages/[...blog]/[tag]/[...page].astro
+++ b/src/pages/[...blog]/[tag]/[...page].astro
@@ -29,7 +29,7 @@ const metadata = {
 };
 
 const rssHref = `/rss/tag/${tag.slug}.xml`;
-const rssFeed = { href: rssHref, title: `${tag.title} — Mage-OS` };
+const rssFeed = { href: rssHref, title: `Mage-OS ${tag.title}` };
 ---
 
 <Layout metadata={metadata} rssFeed={rssFeed}>

--- a/src/pages/[...blog]/[tag]/[...page].astro
+++ b/src/pages/[...blog]/[tag]/[...page].astro
@@ -29,7 +29,7 @@ const metadata = {
 };
 
 const rssHref = `/rss/tag/${tag.slug}.xml`;
-const rssFeed = { href: rssHref, title: `Mage-OS Blog — ${tag.title}` };
+const rssFeed = { href: rssHref, title: `${tag.title} — Mage-OS` };
 ---
 
 <Layout metadata={metadata} rssFeed={rssFeed}>

--- a/src/pages/[...blog]/[tag]/[...page].astro
+++ b/src/pages/[...blog]/[tag]/[...page].astro
@@ -6,6 +6,7 @@ import Layout from '~/layouts/PageLayout.astro';
 import BlogList from '~/components/blog/List.astro';
 import Headline from '~/components/blog/Headline.astro';
 import Pagination from '~/components/blog/Pagination.astro';
+import RssLink from '~/components/blog/RssLink.astro';
 
 export const prerender = true;
 
@@ -26,11 +27,15 @@ const metadata = {
     follow: blogTagRobots?.follow,
   },
 };
+
+const rssHref = `/rss/tag/${tag.slug}.xml`;
+const rssFeed = { href: rssHref, title: `Mage-OS Blog — ${tag.title}` };
 ---
 
-<Layout metadata={metadata}>
+<Layout metadata={metadata} rssFeed={rssFeed}>
   <section class="px-4 md:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
     <Headline>Tag: {tag.title}</Headline>
+    <RssLink href={rssHref} label={`Subscribe to ${tag.title}`} />
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
   </section>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -15,7 +15,7 @@ export const GET = async () => {
   const posts = await fetchPosts();
 
   const rss = await getRssString({
-    title: `Blog — ${SITE.name}`,
+    title: `${SITE.name} Blog`,
     description: METADATA?.description || '',
     site: import.meta.env.SITE,
     items: await buildRssItems(posts),

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -15,7 +15,7 @@ export const GET = async () => {
   const posts = await fetchPosts();
 
   const rss = await getRssString({
-    title: `${SITE.name}’s Blog`,
+    title: `Blog — ${SITE.name}`,
     description: METADATA?.description || '',
     site: import.meta.env.SITE,
     items: await buildRssItems(posts),

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,8 +1,8 @@
 import { getRssString } from '@astrojs/rss';
 
-import { SITE, METADATA, APP_BLOG } from 'astrowind:config';
+import { SITE, METADATA, APP_BLOG, I18N } from 'astrowind:config';
 import { fetchPosts } from '~/utils/blog';
-import { getPermalink } from '~/utils/permalinks';
+import { buildRssItems } from '~/utils/rss';
 
 export const GET = async () => {
   if (!APP_BLOG.isEnabled) {
@@ -18,15 +18,9 @@ export const GET = async () => {
     title: `${SITE.name}’s Blog`,
     description: METADATA?.description || '',
     site: import.meta.env.SITE,
-
-    items: posts.map((post) => ({
-      link: getPermalink(post.permalink, 'post'),
-      title: post.title,
-      description: post.excerpt,
-      pubDate: post.publishDate,
-    })),
-
+    items: await buildRssItems(posts),
     trailingSlash: SITE.trailingSlash,
+    customData: `<language>${I18N?.language || 'en'}</language><lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,
   });
 
   return new Response(rss, {

--- a/src/pages/rss/category/[slug].xml.ts
+++ b/src/pages/rss/category/[slug].xml.ts
@@ -23,7 +23,7 @@ export const GET = async ({ props }: APIContext) => {
   const posts = (await fetchPosts()).filter((post) => post.category?.slug === category.slug);
 
   const rss = await getRssString({
-    title: `${SITE.name}’s Blog — ${category.title}`,
+    title: `${category.title} — ${SITE.name}`,
     description: `Posts in the ${category.title} category`,
     site: import.meta.env.SITE,
     items: await buildRssItems(posts),

--- a/src/pages/rss/category/[slug].xml.ts
+++ b/src/pages/rss/category/[slug].xml.ts
@@ -1,0 +1,39 @@
+import type { APIContext, GetStaticPaths } from 'astro';
+import { getRssString } from '@astrojs/rss';
+
+import { SITE, APP_BLOG, I18N } from 'astrowind:config';
+import { fetchPosts, findCategories } from '~/utils/blog';
+import { buildRssItems } from '~/utils/rss';
+
+export const prerender = true;
+
+export const getStaticPaths = (async () => {
+  if (!APP_BLOG.isEnabled || !APP_BLOG.category.isEnabled) return [];
+
+  const categories = await findCategories();
+  return categories.map((category) => ({
+    params: { slug: category.slug },
+    props: { category },
+  }));
+}) satisfies GetStaticPaths;
+
+export const GET = async ({ props }: APIContext) => {
+  const { category } = props as { category: { slug: string; title: string } };
+
+  const posts = (await fetchPosts()).filter((post) => post.category?.slug === category.slug);
+
+  const rss = await getRssString({
+    title: `${SITE.name}’s Blog — ${category.title}`,
+    description: `Posts in the ${category.title} category`,
+    site: import.meta.env.SITE,
+    items: await buildRssItems(posts),
+    trailingSlash: SITE.trailingSlash,
+    customData: `<language>${I18N?.language || 'en'}</language><lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,
+  });
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+};

--- a/src/pages/rss/category/[slug].xml.ts
+++ b/src/pages/rss/category/[slug].xml.ts
@@ -23,7 +23,7 @@ export const GET = async ({ props }: APIContext) => {
   const posts = (await fetchPosts()).filter((post) => post.category?.slug === category.slug);
 
   const rss = await getRssString({
-    title: `${category.title} — ${SITE.name}`,
+    title: `${SITE.name} ${category.title}`,
     description: `Posts in the ${category.title} category`,
     site: import.meta.env.SITE,
     items: await buildRssItems(posts),

--- a/src/pages/rss/tag/[slug].xml.ts
+++ b/src/pages/rss/tag/[slug].xml.ts
@@ -31,7 +31,7 @@ export const GET = async ({ props }: APIContext) => {
   const posts = (await fetchPosts()).filter((post) => post.tags?.some((t) => t.slug === tag.slug));
 
   const rss = await getRssString({
-    title: `${tag.title} — ${SITE.name}`,
+    title: `${SITE.name} ${tag.title}`,
     description: `Posts tagged ${tag.title}`,
     site: import.meta.env.SITE,
     items: await buildRssItems(posts),

--- a/src/pages/rss/tag/[slug].xml.ts
+++ b/src/pages/rss/tag/[slug].xml.ts
@@ -1,0 +1,47 @@
+import type { APIContext, GetStaticPaths } from 'astro';
+import { getRssString } from '@astrojs/rss';
+
+import { SITE, APP_BLOG, I18N } from 'astrowind:config';
+import { fetchPosts } from '~/utils/blog';
+import { buildRssItems } from '~/utils/rss';
+import type { Taxonomy } from '~/types';
+
+export const prerender = true;
+
+export const getStaticPaths = (async () => {
+  if (!APP_BLOG.isEnabled || !APP_BLOG.tag.isEnabled) return [];
+
+  const posts = await fetchPosts();
+  const tags: Record<string, Taxonomy> = {};
+  posts.forEach((post) => {
+    post.tags?.forEach((tag) => {
+      tags[tag.slug] = tag;
+    });
+  });
+
+  return Object.values(tags).map((tag) => ({
+    params: { slug: tag.slug },
+    props: { tag },
+  }));
+}) satisfies GetStaticPaths;
+
+export const GET = async ({ props }: APIContext) => {
+  const { tag } = props as { tag: Taxonomy };
+
+  const posts = (await fetchPosts()).filter((post) => post.tags?.some((t) => t.slug === tag.slug));
+
+  const rss = await getRssString({
+    title: `${SITE.name}’s Blog — ${tag.title}`,
+    description: `Posts tagged ${tag.title}`,
+    site: import.meta.env.SITE,
+    items: await buildRssItems(posts),
+    trailingSlash: SITE.trailingSlash,
+    customData: `<language>${I18N?.language || 'en'}</language><lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,
+  });
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+};

--- a/src/pages/rss/tag/[slug].xml.ts
+++ b/src/pages/rss/tag/[slug].xml.ts
@@ -31,7 +31,7 @@ export const GET = async ({ props }: APIContext) => {
   const posts = (await fetchPosts()).filter((post) => post.tags?.some((t) => t.slug === tag.slug));
 
   const rss = await getRssString({
-    title: `${SITE.name}’s Blog — ${tag.title}`,
+    title: `${tag.title} — ${SITE.name}`,
     description: `Posts tagged ${tag.title}`,
     site: import.meta.env.SITE,
     items: await buildRssItems(posts),

--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -1,0 +1,37 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+
+import { getPermalink } from '~/utils/permalinks';
+import type { Post } from '~/types';
+
+const renderPostContent = async (post: Post, container: AstroContainer): Promise<string | undefined> => {
+  if (!post.Content) return undefined;
+  try {
+    return await container.renderToString(post.Content);
+  } catch {
+    return undefined;
+  }
+};
+
+export const buildRssItems = async (posts: Array<Post>) => {
+  const container = await AstroContainer.create();
+
+  return Promise.all(
+    posts.map(async (post) => {
+      const content = await renderPostContent(post, container);
+      const categories = [
+        ...(post.category ? [post.category.title] : []),
+        ...(post.tags ?? []).map((tag) => tag.title),
+      ];
+
+      return {
+        link: getPermalink(post.permalink, 'post'),
+        title: post.title,
+        description: post.excerpt,
+        pubDate: post.publishDate,
+        author: post.author,
+        categories: categories.length ? categories : undefined,
+        content,
+      };
+    })
+  );
+};


### PR DESCRIPTION
- Enrich /rss.xml with content:encoded (rendered via Astro Container API),  per-item categories from tags, author, language, and lastBuildDate
- Add per-category feeds at /rss/category/<slug>.xml
- Add per-tag feeds at /rss/tag/<slug>.xml
- Emit <link rel="alternate" type="application/rss+xml"> autodiscovery in  CommonMeta (global main feed) with an optional per-page feed prop threaded  through Layout/PageLayout so tag and category pages advertise their specific feed in addition to the main one
- Add a visible RSS subscribe pill to the blog index, category, and tag  index pages