### PR TITLE
Add Meet Magento UK 2026 event

### DIFF
--- a/src/data/events/2026-07-06-meet-magento-uk-2026.md
+++ b/src/data/events/2026-07-06-meet-magento-uk-2026.md
@@ -1,0 +1,7 @@
+---
+title: Meet Magento UK 2026
+eventDate: "2026-07-06T09:00:00.000Z"
+endDate: "2026-07-07T17:00:00.000Z"
+location: London, UK
+url: https://meet-magento.co.uk/
+---

--- a/src/data/events/2026-07-06-meet-magento-uk-2026.md
+++ b/src/data/events/2026-07-06-meet-magento-uk-2026.md
@@ -4,4 +4,5 @@ eventDate: "2026-07-06T09:00:00.000Z"
 endDate: "2026-07-07T17:00:00.000Z"
 location: London, UK
 url: https://meet-magento.co.uk/
+image: Cubic-Scene-White.jpeg
 ---


### PR DESCRIPTION
## Summary
- Adds `src/data/events/2026-07-06-meet-magento-uk-2026.md` for Meet Magento UK 2026 (July 6-7, London).
- Event was missing from our records; confirmed via https://meet-magento.co.uk/.

## Test plan
- [x] `npm run check` passes
- [x] Event appears on /events listing under the future events

🤖 Generated with [Claude Code](https://claude.com/claude-code)