### PR TITLE
feat: Add information about nightlies builds

### DIFF
--- a/src/pages/product/releases.astro
+++ b/src/pages/product/releases.astro
@@ -187,6 +187,57 @@ bin/magento cache:flush`}
         </tbody>
       </table>
 
+      <h3>Nightly Builds</h3>
+      <p>
+        Nightly builds are auto-generated every night from the latest development branches. They are intended for
+        developers who want to test against upcoming changes — <strong>not for production use</strong>.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Build</th>
+            <th>Composer Repository</th>
+            <th>Tracks</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Mage-OS Nightly</strong></td>
+            <td><a href="https://nightly.mage-os.org/">nightly.mage-os.org</a></td>
+            <td>Latest development state of Mage-OS Distribution</td>
+          </tr>
+          <tr>
+            <td><strong>Upstream Nightly</strong></td>
+            <td><a href="https://upstream-nightly.mage-os.org/">upstream-nightly.mage-os.org</a></td>
+            <td>Latest development state of upstream Magento Open Source</td>
+          </tr>
+        </tbody>
+      </table>
+      <p><strong>Mage-OS Nightly</strong> is useful for:</p>
+      <ul>
+        <li>Extension authors testing compatibility with in-flight Mage-OS changes</li>
+        <li>QA contributors verifying open pull requests</li>
+        <li>Community members who want early access to upcoming features</li>
+      </ul>
+      <p><strong>Upstream Nightly</strong> is useful for:</p>
+      <ul>
+        <li>Developers tracking what Adobe is building before it ships</li>
+        <li>Forward-compatibility testing of extensions against the next Magento release</li>
+      </ul>
+      <Callout type="warning" title="Not for production">
+        Nightly builds are unstable and may contain breaking changes, incomplete features, or untested code. Use them
+        only in isolated development or testing environments.
+      </Callout>
+      <p>Install via Composer:</p>
+      <CodeBlock
+        code={`# Mage-OS Nightly
+composer create-project --repository-url=https://nightly.mage-os.org/ mage-os/project-community-edition:@alpha .
+
+# Upstream Nightly
+composer create-project --repository-url=https://upstream-nightly.mage-os.org/ magento/project-community-edition:@alpha .`}
+        lang="bash"
+      />
+
       <h3>Magento Mirrors</h3>
       <p>
         Mage-OS provides public Magento Open Source mirrors for installing Magento without Adobe Marketplace


### PR DESCRIPTION
## Summary

- Adds a **Nightly Builds** section to the `/product/releases` page under the Repositories section
- Documents both `nightly.mage-os.org` (Mage-OS nightly) and `upstream-nightly.mage-os.org` (upstream Magento Open Source nightly) as Composer repositories
- Explains the target audience for each build (extension authors, QA contributors, forward-compatibility testing)
- Includes correct Composer install commands using the required `:@alpha` stability flag
- Includes a "Not for production" warning callout above the install commands

## Test plan

- [ ] Visit `/product/releases` and verify the Nightly Builds section appears between Mage-OS Lab and Magento Mirrors
- [ ] Confirm both repo URLs link correctly
- [ ] Confirm the warning callout renders above the Composer commands
- [ ] Test the Composer install command: `composer create-project --repository-url=https://nightly.mage-os.org/ mage-os/project-community-edition:@alpha .`

(thank you claude <3)

<img width="1720" height="936" alt="Screenshot 2026-05-03 at 4 46 50 p m" src="https://github.com/user-attachments/assets/49fa607a-1799-41d0-bdf5-1a718348ca6a" />
<img width="1720" height="936" alt="Screenshot 2026-05-03 at 4 49 01 p m" src="https://github.com/user-attachments/assets/895f54c1-910f-4e63-80da-81f0e4141c53" />
<img width="1720" height="972" alt="Screenshot 2026-05-03 at 4 44 21 p m" src="https://github.com/user-attachments/assets/c19fc272-a218-4ead-aca6-66a354129713" />
