### PR TITLE
Add Mage-OS 2.3.0 release blog post

### DIFF
--- a/src/data/post/2026-05-13-mage-os-2-3-0-release.md
+++ b/src/data/post/2026-05-13-mage-os-2-3-0-release.md
@@ -1,0 +1,124 @@
+---
+title: Mage-OS 2.3.0 – Security Patches & PHP 8.5 Compatibility
+excerpt: Mage-OS 2.3.0 incorporates the Magento Open Source 2.4.8-p5 security patches, adds PHP 8.4 and 8.5 compatibility across add-on modules, and tightens template import security in Page Builder.
+publishDate: 2026-05-13T18:00:00
+draft: false
+category: Releases
+image: ~/assets/images/blog/2026/New-Mage-OS-Website.png
+imageAlt: ''
+author: mage-os-team
+---
+
+We are pleased to announce the release of **Mage-OS Distribution 2.3.0**, a security-driven release that absorbs Adobe's latest Magento Open Source patch into the Mage-OS core, inventory, and Page Builder packages. It also rolls out PHP 8.4 and 8.5 compatibility across our add-on module suite. We strongly recommend updating as soon as possible.
+
+> **Final 2.x release.** Mage-OS 2.3.0 is the last release on the 2.x branch. **Mage-OS 3.0**, based on Magento Open Source 2.4.9, will follow soon.
+
+### Our foundation
+
+The majority of changes in this release come directly from upstream. Mage-OS 2.3.0 is built on **Magento Open Source 2.4.8-p5**, which delivers a broad set of security improvements including GraphQL hardening (query complexity, nesting depth, request body size, malicious-code filtering), file upload hardening, database charset/collation handling, and URL rewrite storage refinements.
+
+For full details on what's included from upstream, see the [Magento Open Source 2.4.8-p5 security patch notes](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/security-patches/2-4-8-patches#p5) and the [2.4.8 release notes](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/magento-open-source/2-4-8).
+
+| Software | Version |
+| --- | --- |
+| Composer | 2.9 |
+| OpenSearch | 3.x (or Elasticsearch 8.x) |
+| MariaDB | 11.4 |
+| MySQL | 8.4 |
+| nginx | 1.28 |
+| PHP | 8.3, 8.4 |
+| RabbitMQ | 4.1 |
+| Redis | Valkey 8 (or Redis 7.2+) |
+| Varnish | 7.7 |
+
+### What's changed
+
+#### Core security import
+
+- **Magento 2.4.8-p5 security patches imported**
+  All upstream 2.4.8-p5 security fixes are now incorporated into Mage-OS core, including GraphQL hardening, file upload protections, and DB initialization improvements. ([#229](https://github.com/mage-os/mageos-magento2/pull/229)) by [@marcelmtz](https://github.com/marcelmtz) and [@rhoerr](https://github.com/rhoerr)
+
+- **USPS Carrier corrections layered on top of p5**
+  Corrected the USPS REST default host (`api.usps.com` → `apis.usps.com`), wired up the `XmlAllowedMethods` / `RestAllowedMethods` backend models that p5 introduced but had been left unreferenced, and converged the Carrier, ShipmentService, TrackingService, and ShippingMethodManager classes byte-for-byte with upstream — including the Media-Mail rate dedupe, REST `getAllowedMethods` fallback, and tracking timezone fix.
+
+- **MariaDB version regex fix**
+  Corrected an erroneous version pattern in `app/etc/di.xml` (`^11\.[4|8]\.` → `^11\.[4-8]\.`) so that supported MariaDB versions are properly matched.
+
+- **Page Builder p5 import**
+  Iframe source attribute validation hardening and accompanying translation update. ([#11](https://github.com/mage-os/mageos-magento2-page-builder/pull/11)) by [@rhoerr](https://github.com/rhoerr)
+
+- **Inventory p5 import**
+  Updates to the Ready-for-Pickup admin block and related MFTF coverage. ([#11](https://github.com/mage-os/mageos-inventory/pull/11)) by [@rhoerr](https://github.com/rhoerr)
+
+#### Add-on module updates
+
+- **Page Builder Template Import/Export updated to 1.8.0**
+  - Added a security check on external files referenced through template imports ([@dadolun95](https://github.com/dadolun95))
+  - Refined admin warning and success messaging ([@rhoerr](https://github.com/rhoerr))
+  - PHP 8.4 and 8.5 compatibility, including `SearchResult` signature fixes on `setAggregations` / `setTotalCount` ([@SamueleMartini](https://github.com/SamueleMartini))
+
+- **Theme Optimization updated to 2.3.0**
+  - Enhanced cacheability check in `isRequestCacheable` to tighten correctness of full-page cache eligibility ([#25](https://github.com/mage-os/module-theme-optimization/pull/25)) by [@rhoerr](https://github.com/rhoerr)
+  - PHP 8.4 and 8.5 compatibility with type hardening ([#26](https://github.com/mage-os/module-theme-optimization/pull/26), [#27](https://github.com/mage-os/module-theme-optimization/pull/27))
+
+- **Automatic Translation updated to 2.1.2**
+  PHP 8.4 and 8.5 compatibility. ([#62](https://github.com/mage-os/module-automatic-translation/pull/62)) by [@SamueleMartini](https://github.com/SamueleMartini)
+
+- **Inventory Reservations Grid updated to 1.0.5**
+  PHP 8.4 and 8.5 compatibility. ([#17](https://github.com/mage-os/module-inventory-reservations-grid/pull/17), [#18](https://github.com/mage-os/module-inventory-reservations-grid/pull/18)) by [@SamueleMartini](https://github.com/SamueleMartini)
+
+- **Meta Robots Tag updated to 1.2.1**
+  PHP 8.5 compatibility. ([#7](https://github.com/mage-os/module-meta-robots-tag/pull/7)) by [@SamueleMartini](https://github.com/SamueleMartini)
+
+- **Page Builder Widget updated to 1.4.1**
+  PHP 8.4 compatibility. ([#19](https://github.com/mage-os/module-page-builder-widget/pull/19)) by [@SamueleMartini](https://github.com/SamueleMartini)
+
+### Mirror updates
+
+The latest Magento versions, including 2.4.8-p5, are also available from our public Magento mirror at [mirror.mage-os.org](https://mirror.mage-os.org). This mirror is a drop-in replacement for `repo.magento.com` (except Magento Marketplace), allowing you to install Magento without any login credentials.
+
+### Thanks to everyone who contributed!
+
+This release was made possible by:
+
+- [@marcelmtz](https://github.com/marcelmtz) (Marcel Martinez) — Authored the core 2.4.8-p5 security import
+- [@rhoerr](https://github.com/rhoerr) (Ryan Hoerr) — Co-authored the core p5 import (USPS, MariaDB regex, system.xml conflict resolution), authored the Inventory and Page Builder p5 imports, FPC cacheability fix and PHP 8.5 type hardening in Theme Optimization
+- [@SamueleMartini](https://github.com/SamueleMartini) (Samuele Martini) — PHP 8.4 and 8.5 compatibility across six add-on modules
+- [@dadolun95](https://github.com/dadolun95) (Luca Visciola) — Security check for external files imported through Page Builder templates
+
+### Want to participate?
+
+Mage-OS is a community-driven project, and we welcome contributions of all kinds. Whether you're fixing bugs, adding features, improving documentation, or helping with testing, your contributions make a difference.
+
+- [Mage-OS GitHub](https://github.com/mage-os)
+- [Mage-OS Discord](/discord-channel)
+
+### Installation
+
+#### New installations
+
+```bash
+composer create-project --repository-url=https://repo.mage-os.org/ mage-os/project-community-edition=2.3.0 <install-directory-name>
+```
+
+#### Upgrading from Mage-OS 2.2.x
+
+```bash
+composer require mage-os/product-community-edition=2.3.0 --no-update
+composer update
+bin/magento setup:upgrade
+```
+
+#### Upgrading from an older Mage-OS version
+
+```bash
+composer require mage-os/product-community-edition=^2.3 --no-update
+composer update
+bin/magento setup:upgrade
+```
+
+#### Migrating from Adobe Commerce or Magento Open Source
+
+See our [migration guide](/get-started/migration-guide) for detailed instructions on switching to Mage-OS.
+
+We hope you enjoy Mage-OS 2.3.0. As always, please report any issues on [GitHub](https://github.com/mage-os/mageos-magento2/issues) and join the conversation on [Discord](/discord-channel).

--- a/src/data/post/2026-05-13-mage-os-2-3-0-release.md
+++ b/src/data/post/2026-05-13-mage-os-2-3-0-release.md
@@ -1,5 +1,5 @@
 ---
-title: Mage-OS 2.3.0 – Security Patches & PHP 8.5 Compatibility
+title: Mage-OS 2.3.0 – Maintenance & Security
 excerpt: Mage-OS 2.3.0 incorporates the Magento Open Source 2.4.8-p5 security patches, adds PHP 8.4 and 8.5 compatibility across add-on modules, and tightens template import security in Page Builder.
 publishDate: 2026-05-13T18:00:00
 draft: false
@@ -11,7 +11,9 @@ author: mage-os-team
 
 We are pleased to announce the release of **Mage-OS Distribution 2.3.0**, a security-driven release that absorbs Adobe's latest Magento Open Source patch into the Mage-OS core, inventory, and Page Builder packages. It also rolls out PHP 8.4 and 8.5 compatibility across our add-on module suite. We strongly recommend updating as soon as possible.
 
-> **Final 2.x release.** Mage-OS 2.3.0 is the last release on the 2.x branch. **Mage-OS 3.0**, based on Magento Open Source 2.4.9, will follow soon.
+<Callout type="warning" title="Final 2.x release">
+  Mage-OS 2.3.0 is the last planned release on the 2.x branch. **Mage-OS 3.0**, based on Magento Open Source 2.4.9, will follow soon.
+</Callout>
 
 ### Our foundation
 
@@ -36,21 +38,9 @@ For full details on what's included from upstream, see the [Magento Open Source 
 #### Core security import
 
 - **Magento 2.4.8-p5 security patches imported**
-  All upstream 2.4.8-p5 security fixes are now incorporated into Mage-OS core, including GraphQL hardening, file upload protections, and DB initialization improvements. ([#229](https://github.com/mage-os/mageos-magento2/pull/229)) by [@marcelmtz](https://github.com/marcelmtz) and [@rhoerr](https://github.com/rhoerr)
+  All upstream 2.4.8-p5 security fixes are now incorporated into Mage-OS core, including GraphQL hardening, file upload protections, and DB initialization improvements.
 
-- **USPS Carrier corrections layered on top of p5**
-  Corrected the USPS REST default host (`api.usps.com` → `apis.usps.com`), wired up the `XmlAllowedMethods` / `RestAllowedMethods` backend models that p5 introduced but had been left unreferenced, and converged the Carrier, ShipmentService, TrackingService, and ShippingMethodManager classes byte-for-byte with upstream — including the Media-Mail rate dedupe, REST `getAllowedMethods` fallback, and tracking timezone fix.
-
-- **MariaDB version regex fix**
-  Corrected an erroneous version pattern in `app/etc/di.xml` (`^11\.[4|8]\.` → `^11\.[4-8]\.`) so that supported MariaDB versions are properly matched.
-
-- **Page Builder p5 import**
-  Iframe source attribute validation hardening and accompanying translation update. ([#11](https://github.com/mage-os/mageos-magento2-page-builder/pull/11)) by [@rhoerr](https://github.com/rhoerr)
-
-- **Inventory p5 import**
-  Updates to the Ready-for-Pickup admin block and related MFTF coverage. ([#11](https://github.com/mage-os/mageos-inventory/pull/11)) by [@rhoerr](https://github.com/rhoerr)
-
-#### Add-on module updates
+#### Mage-OS Add-on module updates
 
 - **Page Builder Template Import/Export updated to 1.8.0**
   - Added a security check on external files referenced through template imports ([@dadolun95](https://github.com/dadolun95))
@@ -58,7 +48,7 @@ For full details on what's included from upstream, see the [Magento Open Source 
   - PHP 8.4 and 8.5 compatibility, including `SearchResult` signature fixes on `setAggregations` / `setTotalCount` ([@SamueleMartini](https://github.com/SamueleMartini))
 
 - **Theme Optimization updated to 2.3.0**
-  - Enhanced cacheability check in `isRequestCacheable` to tighten correctness of full-page cache eligibility ([#25](https://github.com/mage-os/module-theme-optimization/pull/25)) by [@rhoerr](https://github.com/rhoerr)
+  - Improved bfcache eligibility on native Full Page Cache hits ([#25](https://github.com/mage-os/module-theme-optimization/pull/25)) by [@rhoerr](https://github.com/rhoerr)
   - PHP 8.4 and 8.5 compatibility with type hardening ([#26](https://github.com/mage-os/module-theme-optimization/pull/26), [#27](https://github.com/mage-os/module-theme-optimization/pull/27))
 
 - **Automatic Translation updated to 2.1.2**
@@ -81,8 +71,8 @@ The latest Magento versions, including 2.4.8-p5, are also available from our pub
 
 This release was made possible by:
 
-- [@marcelmtz](https://github.com/marcelmtz) (Marcel Martinez) — Authored the core 2.4.8-p5 security import
-- [@rhoerr](https://github.com/rhoerr) (Ryan Hoerr) — Co-authored the core p5 import (USPS, MariaDB regex, system.xml conflict resolution), authored the Inventory and Page Builder p5 imports, FPC cacheability fix and PHP 8.5 type hardening in Theme Optimization
+- [@marcelmtz](https://github.com/marcelmtz) (Marcel Martinez) — Merged the core 2.4.8-p5 security changes
+- [@rhoerr](https://github.com/rhoerr) (Ryan Hoerr) — Co-authored the core p5 import (USPS, MariaDB regex, system.xml conflict resolution), FPC cacheability fix and PHP 8.5 type hardening in Theme Optimization
 - [@SamueleMartini](https://github.com/SamueleMartini) (Samuele Martini) — PHP 8.4 and 8.5 compatibility across six add-on modules
 - [@dadolun95](https://github.com/dadolun95) (Luca Visciola) — Security check for external files imported through Page Builder templates
 

--- a/src/data/post/2026-05-13-mage-os-2-3-0-release.mdx
+++ b/src/data/post/2026-05-13-mage-os-2-3-0-release.mdx
@@ -93,14 +93,6 @@ Mage-OS is a community-driven project, and we welcome contributions of all kinds
 composer create-project --repository-url=https://repo.mage-os.org/ mage-os/project-community-edition=2.3.0 <install-directory-name>
 ```
 
-#### Upgrading from Mage-OS 2.2.x
-
-```bash
-composer require mage-os/product-community-edition=2.3.0 --no-update
-composer update
-bin/magento setup:upgrade
-```
-
 #### Upgrading from an older Mage-OS version
 
 ```bash

--- a/src/data/post/2026-05-13-mage-os-2-3-0-release.mdx
+++ b/src/data/post/2026-05-13-mage-os-2-3-0-release.mdx
@@ -9,6 +9,8 @@ imageAlt: ''
 author: mage-os-team
 ---
 
+import Callout from '~/components/ui/Callout.astro';
+
 We are pleased to announce the release of **Mage-OS Distribution 2.3.0**, a security-driven release that absorbs Adobe's latest Magento Open Source patch into the Mage-OS core, inventory, and Page Builder packages. It also rolls out PHP 8.4 and 8.5 compatibility across our add-on module suite. We strongly recommend updating as soon as possible.
 
 <Callout type="warning" title="Final 2.x release">

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -368,7 +368,7 @@ const visionFAQ = [
 <tbody>
 <tr class="border-b border-gray-200 dark:border-gray-700">
 <td class="py-2 pr-4 font-medium">Mage-OS Distribution</td>
-<td class="py-2">Based on Magento Open Source 2.4.8-p4, available and usable today</td>
+<td class="py-2">Based on Magento Open Source 2.4.8-p5, available and usable today</td>
 </tr>
 <tr class="border-b border-gray-200 dark:border-gray-700">
 <td class="py-2 pr-4 font-medium">Mage-OS Lab</td>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -122,7 +122,7 @@ const metadata = {
     title="Built on Magento<sup><small>®</small></sup>, Enhanced by Community"
     items={[
       {
-        title: 'Based on Magento 2.4.8-p4',
+        title: 'Based on Magento 2.4.8-p5',
         description:
           'Built on the rock-solid Magento foundation with all the latest security fixes and platform improvements.',
       },

--- a/src/pages/product/features.astro
+++ b/src/pages/product/features.astro
@@ -40,7 +40,7 @@ const metadata = {
     </Fragment>
 
     <Fragment slot="subtitle">
-      Mage-OS Distribution is built on Magento 2.4.8-p4 with community-driven enhancements for performance, security,
+      Mage-OS Distribution is built on Magento 2.4.8-p5 with community-driven enhancements for performance, security,
       and developer experience. 100% compatible with existing Magento extensions. Free, open source, and ready for
       production.
     </Fragment>
@@ -298,9 +298,9 @@ const metadata = {
             </tr>
             <tr class="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
               <td class="px-4 py-3">Current Base Version</td>
-              <td class="px-4 py-3 text-center">2.4.8-p4</td>
-              <td class="px-4 py-3 text-center">2.4.8-p4</td>
-              <td class="px-4 py-3 text-center">2.4.8-p4</td>
+              <td class="px-4 py-3 text-center">2.4.8-p5</td>
+              <td class="px-4 py-3 text-center">2.4.8-p5</td>
+              <td class="px-4 py-3 text-center">2.4.8-p5</td>
             </tr>
             <tr class="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
               <td class="px-4 py-3">PHP Version Support</td>

--- a/src/pages/product/index.astro
+++ b/src/pages/product/index.astro
@@ -56,7 +56,7 @@ const metadata = {
     title="Built on Solid Foundations"
     subtitle="Proven technology, active community, zero licensing costs"
     stats={[
-      { title: 'Based On', amount: 'Magento 2.4.8-p4' },
+      { title: 'Based On', amount: 'Magento 2.4.8-p5' },
       { title: 'Extension Compatible', amount: '5000+' },
       { title: 'Active Contributors', amount: '100+' },
       { title: 'License Cost', amount: 'Free Forever' },

--- a/src/utils/systemSpecs.ts
+++ b/src/utils/systemSpecs.ts
@@ -281,8 +281,8 @@ function transformData(
   const latestSpecs: VersionSpecs = latestComposite
     ? {
         ...buildComponentSpecs(latestComposite, config),
-        mageosVersion: latestVersion || '2.2.1',
-        magentoBase: latestComposite.upstream || versions[latestVersion]?.magentoBase || '2.4.8-p4',
+        mageosVersion: latestVersion || '2.3.0',
+        magentoBase: latestComposite.upstream || versions[latestVersion]?.magentoBase || '2.4.8-p5',
         releaseDate: latestComposite.release,
         eolDate: latestComposite.eol,
         isLatest: true,


### PR DESCRIPTION
## Summary
- Add Mage-OS 2.3.0 release announcement post, dated 2026-05-13, flagging this as the final 2.x release with 3.0 (based on Magento 2.4.9) to follow
- Bump hardcoded `2.4.8-p4` references to `2.4.8-p5` on homepage, product, features, and FAQ pages
- Update `systemSpecs.ts` fallback values to `2.3.0` / `2.4.8-p5`

## Test plan
- [x] `npm run check` passes
- [x] `npm run dev` — verify the new post renders on `/blog` and as Latest Release on `/product/releases`
- [ ] Spot-check homepage, `/product`, `/product/features`, and `/faq` show `2.4.8-p5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)