### PR TITLE
Add interactive installer to installation and quick-start pages

### DIFF
--- a/src/components/ui/TabbedContent.astro
+++ b/src/components/ui/TabbedContent.astro
@@ -12,9 +12,10 @@ export interface Props {
   tabs: Tab[];
   defaultTab?: string;
   class?: string;
+  label?: string;
 }
 
-const { tabs, defaultTab, class: className } = Astro.props;
+const { tabs, defaultTab, class: className, label } = Astro.props;
 const activeTab = defaultTab || tabs[0]?.id;
 const uniqueId = `tabs-${Math.random().toString(36).slice(2, 9)}`;
 ---
@@ -23,7 +24,7 @@ const uniqueId = `tabs-${Math.random().toString(36).slice(2, 9)}`;
   <!-- Tab List -->
   <div
     role="tablist"
-    aria-label="Content tabs"
+    aria-label={label || 'Content tabs'}
     class="flex border-b border-gray-200 dark:border-gray-700 overflow-x-auto overflow-y-hidden"
   >
     {
@@ -61,12 +62,17 @@ const uniqueId = `tabs-${Math.random().toString(36).slice(2, 9)}`;
 <script>
   function initTabs() {
     document.querySelectorAll('[data-tabs]').forEach((container) => {
-      const tabs = container.querySelectorAll('[role="tab"]');
-      const panelsContainer = container.querySelector('.tab-panels');
+      if ((container as HTMLElement).dataset.tabsInit) return;
+
+      const tabList = container.querySelector(':scope > [role="tablist"]');
+      const tabs = tabList ? tabList.querySelectorAll('[role="tab"]') : [];
+      const panelsContainer = container.querySelector(':scope > .tab-panels');
       if (!panelsContainer) return;
 
-      // Find all tab panel elements (elements with data-tab attribute)
-      const panels = panelsContainer.querySelectorAll('[data-tab]');
+      (container as HTMLElement).dataset.tabsInit = 'true';
+
+      // Only direct children to avoid picking up nested TabbedContent panels
+      const panels = panelsContainer.querySelectorAll(':scope > [data-tab]');
       const activeTab = container.getAttribute('data-active-tab');
 
       // Initialize panel visibility based on activeTab

--- a/src/components/ui/TabbedContent.astro
+++ b/src/components/ui/TabbedContent.astro
@@ -25,7 +25,7 @@ const uniqueId = `tabs-${Math.random().toString(36).slice(2, 9)}`;
   <!-- Tab List -->
   <div
     role="tablist"
-    aria-label={label || 'Content tabs'}
+    aria-label={label ?? 'Content tabs'}
     class="flex border-b border-gray-200 dark:border-gray-700 overflow-x-auto overflow-y-hidden"
   >
     {

--- a/src/components/ui/TabbedContent.astro
+++ b/src/components/ui/TabbedContent.astro
@@ -13,14 +13,15 @@ export interface Props {
   defaultTab?: string;
   class?: string;
   label?: string;
+  prose?: boolean;
 }
 
-const { tabs, defaultTab, class: className, label } = Astro.props;
+const { tabs, defaultTab, class: className, label, prose } = Astro.props;
 const activeTab = defaultTab || tabs[0]?.id;
 const uniqueId = `tabs-${Math.random().toString(36).slice(2, 9)}`;
 ---
 
-<div class={twMerge('not-prose', className)} data-tabs={uniqueId} data-active-tab={activeTab}>
+<div class={twMerge(prose ? null : 'not-prose', className)} data-tabs={uniqueId} data-active-tab={activeTab}>
   <!-- Tab List -->
   <div
     role="tablist"

--- a/src/pages/get-started/installation.astro
+++ b/src/pages/get-started/installation.astro
@@ -26,6 +26,11 @@ const installationTabs = [
   { id: 'docker', label: 'Docker', icon: 'tabler:brand-docker' },
   { id: 'cloud', label: 'Cloud', icon: 'tabler:cloud' },
 ];
+
+const installerTabs = [
+  { id: 'interactive', label: 'Interactive', icon: 'tabler:sparkles' },
+  { id: 'cli', label: 'Command-line', icon: 'tabler:terminal-2' },
+];
 ---
 
 <Layout metadata={metadata}>
@@ -75,7 +80,7 @@ const installationTabs = [
   <!-- Tabbed Installation Methods -->
   <section class="bg-gray-50 dark:bg-slate-800/50 py-16">
     <div class="px-4 sm:px-6 mx-auto lg:px-8 max-w-5xl">
-      <TabbedContent tabs={installationTabs} defaultTab="composer">
+      <TabbedContent tabs={installationTabs} defaultTab="composer" label="Installation method">
         <!-- Composer Tab -->
         <div data-tab="composer">
           <div class="bg-white dark:bg-slate-900 rounded-lg p-6 shadow-sm">
@@ -186,8 +191,15 @@ EXIT;`}
                 Run Installer
               </h4>
 
-              <CodeBlock
-                code={`bin/magento setup:install \\
+              <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
+                <div data-tab="interactive">
+                  <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+                  <CodeBlock code="bin/magento install" lang="bash" />
+                </div>
+                <div data-tab="cli">
+                  <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+                  <CodeBlock
+                    code={`bin/magento setup:install \\
   --base-url="http://your-domain.com/" \\
   --db-host="localhost" \\
   --db-name="mageos" \\
@@ -207,8 +219,10 @@ EXIT;`}
   --opensearch-port="9200" \\
   --opensearch-index-prefix="mageos" \\
   --opensearch-timeout="15"`}
-                lang="bash"
-              />
+                    lang="bash"
+                  />
+                </div>
+              </TabbedContent>
 
               <h4 id="composer-step-5" class="flex items-center gap-2">
                 <span
@@ -349,10 +363,19 @@ ddev start
 
 # Create Mage-OS project
 ddev composer create-project --repository-url=https://repo.mage-os.org/ \\
-  mage-os/project-community-edition .
+  mage-os/project-community-edition .`}
+                  lang="bash"
+                />
 
-# Run installer
-ddev magento setup:install \\
+                <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
+                  <div data-tab="interactive">
+                    <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+                    <CodeBlock code="ddev magento install" lang="bash" />
+                  </div>
+                  <div data-tab="cli">
+                    <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+                    <CodeBlock
+                      code={`ddev magento setup:install \\
   --base-url="https://mageos.ddev.site/" \\
   --db-host="db" \\
   --db-name="db" \\
@@ -365,9 +388,14 @@ ddev magento setup:install \\
   --admin-password="<your-secure-password>" \\
   --search-engine="opensearch" \\
   --opensearch-host="opensearch" \\
-  --opensearch-port="9200"
+  --opensearch-port="9200"`}
+                      lang="bash"
+                    />
+                  </div>
+                </TabbedContent>
 
-# Deploy
+                <CodeBlock
+                  code={`# Deploy
 ddev magento setup:di:compile
 ddev magento setup:static-content:deploy -f
 ddev magento cache:flush`}
@@ -480,10 +508,19 @@ warden env up
 # Enter shell and install Mage-OS
 warden shell
 composer create-project --repository-url=https://repo.mage-os.org/ \\
-  mage-os/project-community-edition .
+  mage-os/project-community-edition .`}
+                  lang="bash"
+                />
 
-# Run installer (inside warden shell)
-bin/magento setup:install \\
+                <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
+                  <div data-tab="interactive">
+                    <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+                    <CodeBlock code="bin/magento install" lang="bash" />
+                  </div>
+                  <div data-tab="cli">
+                    <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+                    <CodeBlock
+                      code={`bin/magento setup:install \\
   --base-url="https://app.mageos.test/" \\
   --db-host="db" \\
   --db-name="magento" \\
@@ -496,9 +533,14 @@ bin/magento setup:install \\
   --admin-password="<your-secure-password>" \\
   --search-engine="opensearch" \\
   --opensearch-host="opensearch" \\
-  --opensearch-port="9200"
+  --opensearch-port="9200"`}
+                      lang="bash"
+                    />
+                  </div>
+                </TabbedContent>
 
-# Deploy static content
+                <CodeBlock
+                  code={`# Deploy static content
 bin/magento setup:di:compile
 bin/magento setup:static-content:deploy -f
 bin/magento cache:flush`}

--- a/src/pages/get-started/quick-start.astro
+++ b/src/pages/get-started/quick-start.astro
@@ -247,7 +247,7 @@ mysql -u root -p -e "FLUSH PRIVILEGES;"`}
 
       <p>Run the installer with your configuration:</p>
 
-      <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
+      <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type" prose>
         <div data-tab="interactive">
           <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
           <CodeBlock code="bin/magento install" lang="bash" />
@@ -276,48 +276,48 @@ mysql -u root -p -e "FLUSH PRIVILEGES;"`}
             lang="bash"
           />
 
-          <p class="mt-4 mb-2 text-base font-normal"><strong>Customize these values:</strong></p>
-          <table class="w-full text-sm">
-            <thead class="border-b border-gray-200 dark:border-gray-700 [&_th]:text-left [&_th]:font-semibold [&_th]:pb-2 [&_th]:pr-6 [&_th]:text-gray-900 dark:[&_th]:text-white">
+          <p><strong>Customize these values:</strong></p>
+          <table>
+            <thead>
               <tr>
                 <th>Parameter</th>
                 <th>Description</th>
                 <th>Example</th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-100 dark:divide-gray-800 text-gray-700 dark:text-gray-300 [&_td]:py-2 [&_td]:pr-6 [&_td:last-child]:pr-0">
+            <tbody>
               <tr>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--base-url</code></td>
+                <td><code>--base-url</code></td>
                 <td>Your store URL</td>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">http://mystore.local/</code></td>
+                <td><code>http://mystore.local/</code></td>
               </tr>
               <tr>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--db-name</code></td>
+                <td><code>--db-name</code></td>
                 <td>Database name</td>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">mage_os</code></td>
+                <td><code>mage_os</code></td>
               </tr>
               <tr>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--db-user</code></td>
+                <td><code>--db-user</code></td>
                 <td>Database username</td>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">mage_os_user</code></td>
+                <td><code>mage_os_user</code></td>
               </tr>
               <tr>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--db-password</code></td>
+                <td><code>--db-password</code></td>
                 <td>Database password</td>
                 <td>Your secure password</td>
               </tr>
               <tr>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--admin-email</code></td>
+                <td><code>--admin-email</code></td>
                 <td>Admin email address</td>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">you@example.com</code></td>
+                <td><code>you@example.com</code></td>
               </tr>
               <tr>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--admin-user</code></td>
+                <td><code>--admin-user</code></td>
                 <td>Admin login username</td>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">admin</code></td>
+                <td><code>admin</code></td>
               </tr>
               <tr>
-                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--admin-password</code></td>
+                <td><code>--admin-password</code></td>
                 <td>Admin login password</td>
                 <td>Min 7 chars, 1 letter, 1 number</td>
               </tr>

--- a/src/pages/get-started/quick-start.astro
+++ b/src/pages/get-started/quick-start.astro
@@ -276,50 +276,50 @@ mysql -u root -p -e "FLUSH PRIVILEGES;"`}
             lang="bash"
           />
 
-          <p class="mt-4 mb-2 text-base"><strong>Customize these values:</strong></p>
+          <p class="mt-4 mb-2 text-base font-normal"><strong>Customize these values:</strong></p>
           <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-gray-200 dark:border-gray-700">
-                <th class="text-left font-semibold py-2 pr-6 text-gray-900 dark:text-white">Parameter</th>
-                <th class="text-left font-semibold py-2 pr-6 text-gray-900 dark:text-white">Description</th>
-                <th class="text-left font-semibold py-2 text-gray-900 dark:text-white">Example</th>
+            <thead class="border-b border-gray-200 dark:border-gray-700 [&_th]:text-left [&_th]:font-semibold [&_th]:pb-2 [&_th]:pr-6 [&_th]:text-gray-900 dark:[&_th]:text-white">
+              <tr>
+                <th>Parameter</th>
+                <th>Description</th>
+                <th>Example</th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-800 text-gray-700 dark:text-gray-300 [&_td]:py-2 [&_td]:pr-6 [&_td:last-child]:pr-0">
               <tr>
-                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--base-url</code></td>
-                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Your store URL</td>
-                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">http://mystore.local/</code></td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--base-url</code></td>
+                <td>Your store URL</td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">http://mystore.local/</code></td>
               </tr>
               <tr>
-                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--db-name</code></td>
-                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Database name</td>
-                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">mage_os</code></td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--db-name</code></td>
+                <td>Database name</td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">mage_os</code></td>
               </tr>
               <tr>
-                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--db-user</code></td>
-                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Database username</td>
-                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">mage_os_user</code></td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--db-user</code></td>
+                <td>Database username</td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">mage_os_user</code></td>
               </tr>
               <tr>
-                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--db-password</code></td>
-                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Database password</td>
-                <td class="py-2 text-gray-700 dark:text-gray-300">Your secure password</td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--db-password</code></td>
+                <td>Database password</td>
+                <td>Your secure password</td>
               </tr>
               <tr>
-                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--admin-email</code></td>
-                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Admin email address</td>
-                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">you@example.com</code></td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--admin-email</code></td>
+                <td>Admin email address</td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">you@example.com</code></td>
               </tr>
               <tr>
-                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--admin-user</code></td>
-                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Admin login username</td>
-                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">admin</code></td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--admin-user</code></td>
+                <td>Admin login username</td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">admin</code></td>
               </tr>
               <tr>
-                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--admin-password</code></td>
-                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Admin login password</td>
-                <td class="py-2 text-gray-700 dark:text-gray-300">Min 7 chars, 1 letter, 1 number</td>
+                <td><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">--admin-password</code></td>
+                <td>Admin login password</td>
+                <td>Min 7 chars, 1 letter, 1 number</td>
               </tr>
             </tbody>
           </table>

--- a/src/pages/get-started/quick-start.astro
+++ b/src/pages/get-started/quick-start.astro
@@ -7,9 +7,15 @@ import ItemGrid from '~/components/ui/ItemGrid.astro';
 import CallToAction from '~/components/widgets/CallToAction.astro';
 import { Icon } from 'astro-icon/components';
 import CodeBlock from '~/components/ui/CodeBlock.astro';
+import TabbedContent from '~/components/ui/TabbedContent.astro';
 import { getLatestSpecs } from '~/utils/systemSpecs';
 
 const specs = await getLatestSpecs();
+
+const installerTabs = [
+  { id: 'interactive', label: 'Interactive', icon: 'tabler:sparkles' },
+  { id: 'cli', label: 'Command-line', icon: 'tabler:terminal-2' },
+];
 
 const metadata = {
   title: 'Quick Start Guide',
@@ -239,10 +245,17 @@ mysql -u root -p -e "FLUSH PRIVILEGES;"`}
         >
       </h2>
 
-      <p>Run the setup installer with your configuration:</p>
+      <p>Run the installer with your configuration:</p>
 
-      <CodeBlock
-        code={`bin/magento setup:install \\
+      <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
+        <div data-tab="interactive">
+          <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+          <CodeBlock code="bin/magento install" lang="bash" />
+        </div>
+        <div data-tab="cli">
+          <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+          <CodeBlock
+            code={`bin/magento setup:install \\
   --base-url=http://yourdomain.local/ \\
   --db-host=localhost \\
   --db-name=mage_os \\
@@ -260,57 +273,58 @@ mysql -u root -p -e "FLUSH PRIVILEGES;"`}
   --search-engine=opensearch \\
   --opensearch-host=localhost \\
   --opensearch-port=9200`}
-        lang="bash"
-      />
+            lang="bash"
+          />
 
-      <p><strong>Customize these values:</strong></p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Parameter</th>
-            <th>Description</th>
-            <th>Example</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>--base-url</code></td>
-            <td>Your store URL</td>
-            <td><code>http://mystore.local/</code></td>
-          </tr>
-          <tr>
-            <td><code>--db-name</code></td>
-            <td>Database name</td>
-            <td><code>mage_os</code></td>
-          </tr>
-          <tr>
-            <td><code>--db-user</code></td>
-            <td>Database username</td>
-            <td><code>mage_os_user</code></td>
-          </tr>
-          <tr>
-            <td><code>--db-password</code></td>
-            <td>Database password</td>
-            <td>Your secure password</td>
-          </tr>
-          <tr>
-            <td><code>--admin-email</code></td>
-            <td>Admin email address</td>
-            <td><code>you@example.com</code></td>
-          </tr>
-          <tr>
-            <td><code>--admin-user</code></td>
-            <td>Admin login username</td>
-            <td><code>admin</code></td>
-          </tr>
-          <tr>
-            <td><code>--admin-password</code></td>
-            <td>Admin login password</td>
-            <td>Min 7 chars, 1 letter, 1 number</td>
-          </tr>
-        </tbody>
-      </table>
+          <p class="mt-4 mb-2 text-base"><strong>Customize these values:</strong></p>
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 dark:border-gray-700">
+                <th class="text-left font-semibold py-2 pr-6 text-gray-900 dark:text-white">Parameter</th>
+                <th class="text-left font-semibold py-2 pr-6 text-gray-900 dark:text-white">Description</th>
+                <th class="text-left font-semibold py-2 text-gray-900 dark:text-white">Example</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+              <tr>
+                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--base-url</code></td>
+                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Your store URL</td>
+                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">http://mystore.local/</code></td>
+              </tr>
+              <tr>
+                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--db-name</code></td>
+                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Database name</td>
+                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">mage_os</code></td>
+              </tr>
+              <tr>
+                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--db-user</code></td>
+                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Database username</td>
+                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">mage_os_user</code></td>
+              </tr>
+              <tr>
+                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--db-password</code></td>
+                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Database password</td>
+                <td class="py-2 text-gray-700 dark:text-gray-300">Your secure password</td>
+              </tr>
+              <tr>
+                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--admin-email</code></td>
+                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Admin email address</td>
+                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">you@example.com</code></td>
+              </tr>
+              <tr>
+                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--admin-user</code></td>
+                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Admin login username</td>
+                <td class="py-2"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">admin</code></td>
+              </tr>
+              <tr>
+                <td class="py-2 pr-6"><code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">--admin-password</code></td>
+                <td class="py-2 pr-6 text-gray-700 dark:text-gray-300">Admin login password</td>
+                <td class="py-2 text-gray-700 dark:text-gray-300">Min 7 chars, 1 letter, 1 number</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </TabbedContent>
 
       <hr class="my-8" />
 


### PR DESCRIPTION
An interactive installer has been added in Mage OS v3 https://mage-os.org/releases/2026-05-18-mage-os-3-0-0-release/

However, the docs do not say anything about it. So I decided it makes sense to add an interactive installer as a possible option, together with a standard `setup:install` command.

Affected pages:
- https://mage-os.org/get-started/installation/
    - Composer and Docker tab -> 'Run Installer' section
- https://mage-os.org/get-started/quick-start/
    - 'Step 3: Run Installation'