### PR TITLE
Update product section and compatibility matrix for Mage-OS 3.0

### DIFF
--- a/src/components/ui/SpecsMatrix.astro
+++ b/src/components/ui/SpecsMatrix.astro
@@ -9,31 +9,41 @@ import VersionBadge from '~/components/ui/VersionBadge.astro';
 import { getSystemSpecs } from '~/utils/systemSpecs';
 
 interface Props {
-  /** Maximum number of versions to display */
+  /** Maximum number of versions to display. Omit to show every release. */
   limit?: number;
   /** Additional classes for the container */
   class?: string;
 }
 
-const { limit = 5, class: className } = Astro.props;
+const { limit, class: className } = Astro.props;
 
 const specs = await getSystemSpecs();
 
-// Sort versions by release date (newest first) and limit
-const sortedVersions = Object.entries(specs.versions)
-  .sort(([, a], [, b]) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime())
-  .slice(0, limit);
+// Extract major.minor from a version string (e.g. "2.2.2" -> "2.2")
+function getMajorMinor(version: string): string {
+  return version.split('.').slice(0, 2).join('.');
+}
+
+// One row per major.minor release line — patch updates are collapsed into their
+// line, represented by its most recent patch. Newest line first.
+const sortedVersions = (() => {
+  const all = Object.entries(specs.versions).sort(
+    ([, a], [, b]) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime()
+  );
+  const seenLines = new Set<string>();
+  const majorMinorOnly = all.filter(([version]) => {
+    const line = getMajorMinor(version);
+    if (seenLines.has(line)) return false;
+    seenLines.add(line);
+    return true;
+  });
+  return typeof limit === 'number' ? majorMinorOnly.slice(0, limit) : majorMinorOnly;
+})();
 
 // Format date for display
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
   return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-}
-
-// Extract major.minor from version string
-function getMajorMinor(version: string): string {
-  const parts = version.split('.');
-  return parts.slice(0, 2).join('.');
 }
 ---
 
@@ -60,36 +70,16 @@ function getMajorMinor(version: string): string {
                 versionSpecs.isLatest ? 'bg-green-50 dark:bg-green-900/20' : '',
               ]}
             >
-              <td class="py-3 px-4 font-bold">
+              <td class="py-3 px-4 font-bold whitespace-nowrap">
                 {getMajorMinor(version)}
                 {versionSpecs.isLatest && <VersionBadge status="recommended" class="ml-2" />}
               </td>
-              <td class="py-3 px-4">
-                {versionSpecs.php.minimum === versionSpecs.php.recommended
-                  ? versionSpecs.php.recommended
-                  : `${versionSpecs.php.minimum}-${versionSpecs.php.recommended}`}
-              </td>
-              <td class="py-3 px-4">
-                <span title="MySQL">MySQL {versionSpecs.mysql.minimum}+</span>
-                <span class="text-gray-400 mx-1">/</span>
-                <span title="MariaDB">MariaDB {versionSpecs.mariadb.minimum}+</span>
-              </td>
-              <td class="py-3 px-4">
-                <span title="OpenSearch">OS {versionSpecs.opensearch.minimum}+</span>
-                {versionSpecs.elasticsearch && (
-                  <>
-                    <span class="text-gray-400 mx-1">/</span>
-                    <span title="Elasticsearch">ES {versionSpecs.elasticsearch.minimum}+</span>
-                  </>
-                )}
-              </td>
-              <td class="py-3 px-4">
-                <span title="Valkey">Valkey {versionSpecs.valkey.minimum}+</span>
-                <span class="text-gray-400 mx-1">/</span>
-                <span title="Redis">Redis {versionSpecs.redis.minimum}+</span>
-              </td>
-              <td class="py-3 px-4">{versionSpecs.magentoBase}</td>
-              <td class="py-3 px-4">{formatDate(versionSpecs.releaseDate)}</td>
+              <td class="py-3 px-4 whitespace-nowrap">{versionSpecs.phpDisplay || versionSpecs.php.recommended}</td>
+              <td class="py-3 px-4 whitespace-nowrap">{versionSpecs.databaseDisplay || '—'}</td>
+              <td class="py-3 px-4 whitespace-nowrap">{versionSpecs.searchDisplay || '—'}</td>
+              <td class="py-3 px-4 whitespace-nowrap">{versionSpecs.cacheDisplay || '—'}</td>
+              <td class="py-3 px-4 whitespace-nowrap">{versionSpecs.magentoBase}</td>
+              <td class="py-3 px-4 whitespace-nowrap">{formatDate(versionSpecs.releaseDate)}</td>
             </tr>
           ))
         }

--- a/src/data/post/2026-05-13-mage-os-2-3-0-release.mdx
+++ b/src/data/post/2026-05-13-mage-os-2-3-0-release.mdx
@@ -14,7 +14,8 @@ import Callout from '~/components/ui/Callout.astro';
 We are pleased to announce the release of **Mage-OS Distribution 2.3.0**, a security-driven release that absorbs Adobe's latest Magento Open Source patch into the Mage-OS core, inventory, and Page Builder packages. It also rolls out PHP 8.4 and 8.5 compatibility across our add-on module suite. We strongly recommend updating as soon as possible.
 
 <Callout type="warning" title="Final 2.x release">
-  Mage-OS 2.3.0 is the last planned release on the 2.x branch. **Mage-OS 3.0**, based on Magento Open Source 2.4.9, will follow soon.
+  Mage-OS 2.3.0 is the last planned release on the 2.x branch. **Mage-OS 3.0**, based on Magento Open Source 2.4.9, will
+  follow soon.
 </Callout>
 
 ### Our foundation
@@ -23,17 +24,17 @@ The majority of changes in this release come directly from upstream. Mage-OS 2.3
 
 For full details on what's included from upstream, see the [Magento Open Source 2.4.8-p5 security patch notes](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/security-patches/2-4-8-patches#p5) and the [2.4.8 release notes](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/magento-open-source/2-4-8).
 
-| Software | Version |
-| --- | --- |
-| Composer | 2.9 |
+| Software   | Version                    |
+| ---------- | -------------------------- |
+| Composer   | 2.9                        |
 | OpenSearch | 3.x (or Elasticsearch 8.x) |
-| MariaDB | 11.4 |
-| MySQL | 8.4 |
-| nginx | 1.28 |
-| PHP | 8.3, 8.4 |
-| RabbitMQ | 4.1 |
-| Redis | Valkey 8 (or Redis 7.2+) |
-| Varnish | 7.7 |
+| MariaDB    | 11.4                       |
+| MySQL      | 8.4                        |
+| nginx      | 1.28                       |
+| PHP        | 8.3, 8.4                   |
+| RabbitMQ   | 4.1                        |
+| Redis      | Valkey 8 (or Redis 7.2+)   |
+| Varnish    | 7.7                        |
 
 ### What's changed
 

--- a/src/data/post/2026-05-18-mage-os-3-0-0-release.mdx
+++ b/src/data/post/2026-05-18-mage-os-3-0-0-release.mdx
@@ -103,7 +103,7 @@ The admin footer now shows an **"Update available: X.Y.Z"** link when a new rele
 
 Mage-OS 3.0 introduces `mage-os/product-minimal-edition` — a lean install with only ~98 core packages installed by default. Modules, themes, and language packs are available as individual Composer packages, so you only install what you use. Best for teams comfortable composing their own stack and looking to optimize every millsecond.
 
-Packages that aren't included by default should be auto-installed by composer for extensions that need them, as long as those dependencies are declared properly.  It's up to you to add what you need (Page Builder, Inventory, GraphQL, etc).
+Packages that aren't included by default should be auto-installed by composer for extensions that need them, as long as those dependencies are declared properly. It's up to you to add what you need (Page Builder, Inventory, GraphQL, etc).
 
 For more details, and to browse all of the packages that are available and included, see our website's new [Package Browser](/product/minimal).
 

--- a/src/data/system-specs-config.yaml
+++ b/src/data/system-specs-config.yaml
@@ -7,7 +7,7 @@
 components:
   php:
     minimum: '8.3'
-    recommended: '8.4'
+    recommended: '8.5'
 
   composer:
     minimum: '2.7'

--- a/src/pages/get-started/installation.astro
+++ b/src/pages/get-started/installation.astro
@@ -193,11 +193,16 @@ EXIT;`}
 
               <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
                 <div data-tab="interactive">
-                  <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+                  <p class="text-sm text-muted mb-3">
+                    Walks you through every setting interactively - no flags to memorize. Recommended for first-time
+                    setups.
+                  </p>
                   <CodeBlock code="bin/magento install" lang="bash" />
                 </div>
                 <div data-tab="cli">
-                  <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+                  <p class="text-sm text-muted mb-3">
+                    Pass all options as flags in a single command. Useful for scripted or automated deployments.
+                  </p>
                   <CodeBlock
                     code={`bin/magento setup:install \\
   --base-url="http://your-domain.com/" \\
@@ -369,11 +374,16 @@ ddev composer create-project --repository-url=https://repo.mage-os.org/ \\
 
                 <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
                   <div data-tab="interactive">
-                    <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+                    <p class="text-sm text-muted mb-3">
+                      Walks you through every setting interactively - no flags to memorize. Recommended for first-time
+                      setups.
+                    </p>
                     <CodeBlock code="ddev magento install" lang="bash" />
                   </div>
                   <div data-tab="cli">
-                    <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+                    <p class="text-sm text-muted mb-3">
+                      Pass all options as flags in a single command. Useful for scripted or automated deployments.
+                    </p>
                     <CodeBlock
                       code={`ddev magento setup:install \\
   --base-url="https://mageos.ddev.site/" \\
@@ -514,11 +524,16 @@ composer create-project --repository-url=https://repo.mage-os.org/ \\
 
                 <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type">
                   <div data-tab="interactive">
-                    <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+                    <p class="text-sm text-muted mb-3">
+                      Walks you through every setting interactively - no flags to memorize. Recommended for first-time
+                      setups.
+                    </p>
                     <CodeBlock code="bin/magento install" lang="bash" />
                   </div>
                   <div data-tab="cli">
-                    <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+                    <p class="text-sm text-muted mb-3">
+                      Pass all options as flags in a single command. Useful for scripted or automated deployments.
+                    </p>
                     <CodeBlock
                       code={`bin/magento setup:install \\
   --base-url="https://app.mageos.test/" \\

--- a/src/pages/get-started/quick-start.astro
+++ b/src/pages/get-started/quick-start.astro
@@ -249,11 +249,15 @@ mysql -u root -p -e "FLUSH PRIVILEGES;"`}
 
       <TabbedContent tabs={installerTabs} defaultTab="interactive" label="Installer type" prose>
         <div data-tab="interactive">
-          <p class="text-sm text-muted mb-3">Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.</p>
+          <p class="text-sm text-muted mb-3">
+            Walks you through every setting interactively - no flags to memorize. Recommended for first-time setups.
+          </p>
           <CodeBlock code="bin/magento install" lang="bash" />
         </div>
         <div data-tab="cli">
-          <p class="text-sm text-muted mb-3">Pass all options as flags in a single command. Useful for scripted or automated deployments.</p>
+          <p class="text-sm text-muted mb-3">
+            Pass all options as flags in a single command. Useful for scripted or automated deployments.
+          </p>
           <CodeBlock
             code={`bin/magento setup:install \\
   --base-url=http://yourdomain.local/ \\

--- a/src/pages/get-started/system-requirements.astro
+++ b/src/pages/get-started/system-requirements.astro
@@ -546,9 +546,9 @@ max_connections = 150`}</code></pre>
   <!-- Compatibility Matrix Section -->
   <section class="bg-gray-50 dark:bg-slate-800/50 py-16">
     <div class="px-4 sm:px-6 mx-auto lg:px-8 max-w-5xl">
-      <Headline title="Compatibility Matrix" subtitle="Mage-OS version requirements at a glance" />
+      <Headline title="Compatibility Matrix" subtitle="Component requirements for every Mage-OS release" />
 
-      <SpecsMatrix limit={5} />
+      <SpecsMatrix />
 
       <p class="text-center text-muted mt-6">
         For the latest version information, see the <a href="/product/releases" class="text-primary hover:underline"

--- a/src/pages/product/roadmap.astro
+++ b/src/pages/product/roadmap.astro
@@ -64,7 +64,7 @@ const metadata = {
           </div>
           <div>
             <h3 class="text-lg font-bold dark:text-white">Minor</h3>
-            <span class="text-sm text-muted">2.#.0</span>
+            <span class="text-sm text-muted">#.#.0</span>
           </div>
         </div>
         <p class="text-muted mb-3">Security patches, compatibility updates.</p>
@@ -81,7 +81,7 @@ const metadata = {
           </div>
           <div>
             <h3 class="text-lg font-bold dark:text-white">Patch</h3>
-            <span class="text-sm text-muted">2.0.#</span>
+            <span class="text-sm text-muted">#.#.#</span>
           </div>
         </div>
         <p class="text-muted mb-3">Critical off-schedule fixes.</p>
@@ -108,9 +108,9 @@ const metadata = {
           <Icon name="tabler:star" class="w-8 h-8 text-green-600 dark:text-green-400" />
         </div>
         <div>
-          <h2 class="text-3xl font-bold font-heading text-green-800 dark:text-green-200">Current Release: Mage-OS 2</h2>
+          <h2 class="text-3xl font-bold font-heading text-green-800 dark:text-green-200">Current Release: Mage-OS 3</h2>
           <p class="text-green-700 dark:text-green-300">
-            Released in late 2025, our most feature-rich release to date.
+            Released May 2026 on Magento Open Source 2.4.9, our most feature-rich release to date.
           </p>
         </div>
       </div>
@@ -119,40 +119,36 @@ const metadata = {
         columns={2}
         items={[
           {
-            title: 'PCI DSS 4.0 Compliance',
+            title: 'Interactive Installer',
             description:
-              'Enhanced security policies including automatic account deactivation and strengthened authentication.',
-            icon: 'tabler:shield-lock',
+              'A guided <code>bin/magento install</code> wizard with service auto-detection, resume-on-failure, and optional Hyvä setup.',
+            icon: 'tabler:terminal-2',
           },
           {
-            title: 'AI-Powered Translation',
+            title: 'Returns (RMA)',
             description:
-              'Automatic translation via DeepL, OpenAI, or Google Gemini for products, categories, and CMS content.',
-            icon: 'tabler:language',
+              'Built-in Return Merchandise Authorization — customers request returns and merchants review, approve, and respond.',
+            icon: 'tabler:package-import',
           },
           {
-            title: 'Inventory Reservations Grid',
-            description: 'Direct visibility and management of stock reservations in the admin panel.',
-            icon: 'tabler:box',
+            title: 'Admin Activity Log',
+            description: 'A built-in audit trail of who changed what and when, for auditing and compliance.',
+            icon: 'tabler:history',
           },
           {
-            title: 'Meta Robots Control',
-            description: 'Fine-grained NOINDEX, NOFOLLOW, and NOARCHIVE settings per page for better SEO.',
-            icon: 'tabler:robot',
+            title: 'Minimal Distribution',
+            description:
+              'A lean install of ~98 core packages, with everything else available as individual Composer packages.',
+            icon: 'tabler:package',
           },
           {
-            title: 'PageBuilder Enhancements',
-            description: 'CMS Widget support with live previews and import/export capabilities.',
-            icon: 'tabler:layout-grid',
+            title: 'Bundled Developer Toolkit',
+            description: 'n98-magerun2 and other established community tools shipped by default.',
+            icon: 'tabler:tools',
           },
           {
-            title: 'Theme Optimization',
-            description: 'Back/forward cache support, speculative preloading, and smooth page transitions.',
-            icon: 'tabler:bolt',
-          },
-          {
-            title: 'PHP 8.4 Support',
-            description: 'Full compatibility with the latest PHP version for improved performance and features.',
+            title: 'PHP 8.5 Support',
+            description: 'Built on Magento Open Source 2.4.9, with PHP 8.5 support and faster compiled performance.',
             icon: 'tabler:brand-php',
           },
         ]}
@@ -168,7 +164,7 @@ const metadata = {
           class="inline-flex items-center gap-2 px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium"
         >
           <Icon name="tabler:download" class="w-5 h-5" />
-          Get Started with Mage-OS 2
+          Get Started with Mage-OS 3
         </a>
       </div>
     </div>
@@ -184,13 +180,13 @@ const metadata = {
       {
         title: 'Q1 2026 <span class="text-sm font-normal text-muted ml-2">(January - March)</span>',
         description:
-          '<strong>Mage-OS 2.1-2.4</strong> - Minor releases incorporating upstream security patches. Plus continued Lab module evaluations, developer experience improvements, and documentation expansion.',
+          '<strong>Mage-OS 2.1-2.2</strong> - Minor releases incorporating upstream security patches. Plus continued Lab module evaluations, developer experience improvements, and documentation expansion.',
         icon: 'tabler:calendar-event',
       },
       {
         title: 'Q2 2026 <span class="text-sm font-normal text-muted ml-2">(April - June)</span>',
         description:
-          '<strong>Mage-OS 3.0</strong> - Next major release aligned with Magento feature release. New community-driven features from the Mage-OS Lab and system requirement updates as needed.',
+          '<strong>Mage-OS 2.3 &amp; 3.0</strong> - Mage-OS 3.0, our next major release, shipped in May on Magento Open Source 2.4.9 with PHP 8.5 support, new Mage-OS Lab features, and updated system requirements.',
         icon: 'tabler:rocket',
       },
       {
@@ -318,9 +314,25 @@ const metadata = {
     <div class="bg-green-50 dark:bg-green-900/20 rounded-lg p-6 mb-8">
       <h4 class="text-lg font-bold mb-4 flex items-center gap-2 text-green-800 dark:text-green-200">
         <Icon name="tabler:trophy" class="w-6 h-6" />
-        Recent Graduates (Now in Mage-OS 2)
+        Lab Graduates (Now in Mage-OS)
       </h4>
       <div class="grid sm:grid-cols-2 gap-3">
+        <div class="flex items-center gap-2 text-green-700 dark:text-green-300">
+          <Icon name="tabler:check" class="w-5 h-5" />
+          <span>Interactive installer (community-contributed)</span>
+        </div>
+        <div class="flex items-center gap-2 text-green-700 dark:text-green-300">
+          <Icon name="tabler:check" class="w-5 h-5" />
+          <span>Returns (RMA) management</span>
+        </div>
+        <div class="flex items-center gap-2 text-green-700 dark:text-green-300">
+          <Icon name="tabler:check" class="w-5 h-5" />
+          <span>Admin Activity Log audit trail</span>
+        </div>
+        <div class="flex items-center gap-2 text-green-700 dark:text-green-300">
+          <Icon name="tabler:check" class="w-5 h-5" />
+          <span>Bundled developer toolkit (n98-magerun2 and more)</span>
+        </div>
         <div class="flex items-center gap-2 text-green-700 dark:text-green-300">
           <Icon name="tabler:check" class="w-5 h-5" />
           <span>AI-Powered Translation module</span>
@@ -448,7 +460,7 @@ const metadata = {
           </li>
           <li class="flex items-start gap-2">
             <Icon name="tabler:check" class="w-4 h-4 text-green-500 mt-1 flex-shrink-0" />
-            <span>Mage-OS Distribution 1.0 and 2.0 releases</span>
+            <span>Mage-OS Distribution 1.0, 2.0, and 3.0 releases</span>
           </li>
           <li class="flex items-start gap-2">
             <Icon name="tabler:check" class="w-4 h-4 text-green-500 mt-1 flex-shrink-0" />

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -311,6 +311,15 @@ export interface VersionSpecs extends ComponentSpecs {
   releaseDate: string;
   eolDate: string;
   isLatest: boolean;
+  /**
+   * Per-release display strings sourced directly from the version feed (not the
+   * config overrides). Used by the compatibility matrix so each release row
+   * reflects the versions it actually shipped against.
+   */
+  phpDisplay?: string;
+  databaseDisplay?: string;
+  searchDisplay?: string;
+  cacheDisplay?: string;
 }
 
 export interface SystemSpecs {

--- a/src/utils/systemSpecs.ts
+++ b/src/utils/systemSpecs.ts
@@ -31,6 +31,7 @@ const GitHubVersionEntrySchema = z.object({
   elasticsearch: z.string().optional(),
   rabbitmq: z.string().optional(),
   redis: z.string().optional(),
+  valkey: z.string().optional(),
   varnish: z.string().optional(),
   nginx: z.string().optional(),
   os: z.string().optional(),
@@ -110,6 +111,45 @@ function extractVersion(imageString: string | undefined): string {
   if (!imageString) return '';
   const match = imageString.match(/:(\d+\.?\d*)/);
   return match ? match[1] : '';
+}
+
+/**
+ * Format a Docker image string into a human-friendly "Engine x.y" label.
+ * e.g. "mariadb:10.6" -> "MariaDB 10.6", "mysql:8.4" -> "MySQL 8.4"
+ */
+function formatImageLabel(imageString: string | undefined, labels: Record<string, string>): string {
+  if (!imageString) return '';
+  const name = imageString.split(':')[0].split('/').pop() || '';
+  const version = extractVersion(imageString);
+  const label = labels[name.toLowerCase()] || name;
+  return version ? `${label} ${version}` : label;
+}
+
+/**
+ * Build the per-release database label from the feed entry. The feed reuses the
+ * `mysql` field for MariaDB images, so the engine is derived from the image name.
+ */
+function formatDatabaseDisplay(entry: GitHubVersionEntry): string {
+  return formatImageLabel(entry.mysql, { mysql: 'MySQL', mariadb: 'MariaDB' });
+}
+
+/**
+ * Build the per-release search engine label, preferring OpenSearch over the
+ * legacy Elasticsearch field used by older releases.
+ */
+function formatSearchDisplay(entry: GitHubVersionEntry): string {
+  return formatImageLabel(entry.opensearch || entry.elasticsearch, {
+    opensearch: 'OpenSearch',
+    elasticsearch: 'Elasticsearch',
+  });
+}
+
+/**
+ * Build the per-release cache label, preferring Valkey (used by newer releases)
+ * over the Redis field used by earlier ones.
+ */
+function formatCacheDisplay(entry: GitHubVersionEntry): string {
+  return formatImageLabel(entry.valkey || entry.redis, { redis: 'Redis', valkey: 'Valkey' });
 }
 
 /**
@@ -260,6 +300,12 @@ function transformData(
       releaseDate: entry.release,
       eolDate: entry.eol,
       isLatest: false,
+      // Per-release values straight from the feed, so each matrix row reflects
+      // what that release actually shipped against (not the global config).
+      phpDisplay: String(entry.php),
+      databaseDisplay: formatDatabaseDisplay(entry),
+      searchDisplay: formatSearchDisplay(entry),
+      cacheDisplay: formatCacheDisplay(entry),
     };
   }
 


### PR DESCRIPTION
## Summary
- Roadmap reflects **Mage-OS 3** as the current release (Magento Open Source 2.4.9, PHP 8.5): refreshed headline features and Lab graduates, version-agnostic release-scheme badges, and the 2026 timeline corrected now that 3.0 has shipped.
- Compatibility matrix now shows **one row per major.minor release line** (patch updates collapsed), each reflecting that line's actual shipped PHP/DB/search/cache from the version feed.
- `systemSpecs` sources per-release specs from the feed and adds `valkey` to the schema; recommended PHP bumped to 8.5 in the config.
- Bundled fix: Prettier formatting on the 2.3/3.0 release posts and install guides already on `main`.

## Test plan
- `npm run check` — 0 errors, Prettier clean
- `npm run build` — succeeds; verified the matrix renders 9 major.minor rows (1.0 → 3.0, 3.0 marked Recommended) and the system-requirements quick reference shows PHP 8.5