### PR TITLE
Update system requirements for Mage-OS 3.2.0

### DIFF
--- a/src/data/system-specs-config.yaml
+++ b/src/data/system-specs-config.yaml
@@ -10,16 +10,16 @@ components:
     recommended: '8.5'
 
   composer:
-    minimum: '2.7'
-    recommended: '2.9.3'
+    minimum: '2.10.2'
+    recommended: '2.10.2'
 
   mysql:
-    minimum: '8.0'
+    minimum: '8.4'
     recommended: '8.4'
 
   mariadb:
-    minimum: '10.6'
-    recommended: '11.4'
+    minimum: '11.4'
+    recommended: '12.3'
 
   opensearch:
     minimum: '2'
@@ -30,8 +30,8 @@ components:
     supported: '8.x'
 
   redis:
-    minimum: '7.0'
-    recommended: '7.2'
+    minimum: '7.2'
+    recommended: '8.0'
 
   valkey:
     minimum: '7.0'
@@ -50,5 +50,5 @@ components:
     recommended: '2.4'
 
   rabbitmq:
-    minimum: '3.13'
+    minimum: '4.0'
     recommended: '4.1'

--- a/src/pages/get-started/index.astro
+++ b/src/pages/get-started/index.astro
@@ -219,7 +219,7 @@ const metadata = {
     subtitle="Most modern hosting environments meet these requirements. Check our detailed system requirements page for compatibility notes."
     items={[
       {
-        title: `PHP ${specs.php.minimum} or ${specs.php.recommended}`,
+        title: `PHP ${specs.php.minimum} - ${specs.php.recommended}`,
         description: 'With required extensions (intl, soap, gd, etc.)',
         icon: 'tabler:brand-php',
       },

--- a/src/pages/get-started/quick-start.astro
+++ b/src/pages/get-started/quick-start.astro
@@ -60,7 +60,7 @@ const metadata = {
         <tbody>
           <tr>
             <td>PHP</td>
-            <td>{specs.php.minimum} or {specs.php.recommended}</td>
+            <td>{specs.php.minimum} - {specs.php.recommended}</td>
           </tr>
           <tr>
             <td>Composer</td>

--- a/src/pages/get-started/system-requirements.astro
+++ b/src/pages/get-started/system-requirements.astro
@@ -69,24 +69,29 @@ const metadata = {
               <tr class="border-b dark:border-gray-700">
                 <th class="text-left py-2 font-medium">Distribution</th>
                 <th class="text-left py-2 font-medium">Min Version</th>
+                <th class="text-left py-2 font-medium">Recommended</th>
               </tr>
             </thead>
             <tbody class="text-muted">
               <tr class="border-b dark:border-gray-700">
                 <td class="py-2">Ubuntu LTS</td>
-                <td class="py-2">22.04 <VersionBadge status="recommended" class="ml-2" /></td>
+                <td class="py-2">22.04</td>
+                <td class="py-2">24.04 <VersionBadge status="recommended" class="ml-2" /></td>
               </tr>
               <tr class="border-b dark:border-gray-700">
                 <td class="py-2">Debian</td>
-                <td class="py-2">12 <VersionBadge status="supported" class="ml-2" /></td>
+                <td class="py-2">12</td>
+                <td class="py-2">13 <VersionBadge status="supported" class="ml-2" /></td>
               </tr>
               <tr class="border-b dark:border-gray-700">
                 <td class="py-2">Rocky Linux</td>
-                <td class="py-2">9 <VersionBadge status="supported" class="ml-2" /></td>
+                <td class="py-2">9</td>
+                <td class="py-2">10 <VersionBadge status="supported" class="ml-2" /></td>
               </tr>
               <tr>
                 <td class="py-2">AlmaLinux</td>
-                <td class="py-2">9 <VersionBadge status="supported" class="ml-2" /></td>
+                <td class="py-2">9</td>
+                <td class="py-2">10 <VersionBadge status="supported" class="ml-2" /></td>
               </tr>
             </tbody>
           </table>
@@ -100,7 +105,7 @@ const metadata = {
           <ul class="space-y-3 text-muted">
             <li class="flex items-center gap-2">
               <Icon name="tabler:brand-apple" class="w-5 h-5" />
-              <span><strong>macOS:</strong> 13+ (Ventura or later)</span>
+              <span><strong>macOS:</strong> 14+ (Sonoma or later)</span>
             </li>
             <li class="flex items-center gap-2">
               <Icon name="tabler:brand-windows" class="w-5 h-5" />
@@ -184,14 +189,31 @@ const metadata = {
               <VersionBadge status="recommended" class="ml-2" />
             </div>
           </div>
+          {
+            specs.phpDisplay &&
+              specs.phpDisplay !== specs.php.recommended &&
+              specs.phpDisplay !== specs.php.minimum && (
+                <div class="flex items-center gap-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg px-4 py-3">
+                  <Icon name="tabler:brand-php" class="w-8 h-8 text-blue-600 dark:text-blue-400" />
+                  <div>
+                    <span class="text-2xl font-bold text-blue-700 dark:text-blue-300">PHP {specs.phpDisplay}</span>
+                    <VersionBadge status="supported" class="ml-2" />
+                  </div>
+                </div>
+              )
+          }
           <div class="flex items-center gap-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg px-4 py-3">
             <Icon name="tabler:brand-php" class="w-8 h-8 text-blue-600 dark:text-blue-400" />
             <div>
               <span class="text-2xl font-bold text-blue-700 dark:text-blue-300">PHP {specs.php.minimum}</span>
-              <VersionBadge status="supported" class="ml-2" />
+              <VersionBadge status="minimum" class="ml-2" />
             </div>
           </div>
         </div>
+        <p class="mt-4 text-sm text-muted">
+          Mage-OS {specs.mageosVersion} runs on PHP {specs.php.minimum} through {specs.php.recommended}.
+          {specs.phpDisplay && <>Upstream CI builds and tests against PHP {specs.phpDisplay}.</>}
+        </p>
       </div>
 
       <div class="bg-white dark:bg-slate-900 rounded-lg p-6 shadow-sm">
@@ -212,6 +234,7 @@ const metadata = {
               'libxml',
               'mbstring',
               'openssl',
+              'pcntl',
               'pcre',
               'pdo_mysql',
               'simplexml',
@@ -256,7 +279,7 @@ const metadata = {
         {
           name: 'Percona',
           minimum: specs.mysql.minimum,
-          recommended: specs.mysql.minimum,
+          recommended: specs.mysql.recommended,
           notes: 'Enterprise MySQL variant',
           showRecBadge: false,
         },
@@ -317,7 +340,7 @@ max_connections = 150`}</code></pre>
           <p class="text-muted mb-4">Requires license for some features. Legacy option.</p>
           <div class="text-sm">
             <span class="text-gray-500">Min:</span>
-            {specs.elasticsearch?.minimum || '7.17'}
+            {specs.elasticsearch?.minimum || '8.x'}
             <span class="mx-2">|</span>
             <span class="text-blue-600 dark:text-blue-400 font-medium"
               >Supported: {specs.elasticsearch?.recommended || '8.x'}</span

--- a/src/utils/systemSpecs.ts
+++ b/src/utils/systemSpecs.ts
@@ -327,11 +327,15 @@ function transformData(
   const latestSpecs: VersionSpecs = latestComposite
     ? {
         ...buildComponentSpecs(latestComposite, config),
-        mageosVersion: latestVersion || '2.3.0',
-        magentoBase: latestComposite.upstream || versions[latestVersion]?.magentoBase || '2.4.8-p5',
+        mageosVersion: latestVersion || '3.2.0',
+        magentoBase: latestComposite.upstream || versions[latestVersion]?.magentoBase || '2.4.9',
         releaseDate: latestComposite.release,
         eolDate: latestComposite.eol,
         isLatest: true,
+        // The PHP version upstream CI actually builds and tests against. Sits
+        // between the configured minimum and recommended, so the requirements
+        // page can surface it without hardcoding a version that goes stale.
+        phpDisplay: String(latestComposite.php),
       }
     : versions[latestVersion];
 


### PR DESCRIPTION
Follows up on community feedback that https://mage-os.org/get-started/system-requirements/ is out of date, and specifically that 3.2.0 supports MariaDB 12.3.

The Compatibility Matrix at the bottom of the page was already correct — it reads the version feed directly. Everything else comes from `src/data/system-specs-config.yaml` or is hardcoded, and that is what had drifted. **Several listed minimums are now past their upstream EOL dates.**

## Component versions

`src/data/system-specs-config.yaml` also feeds the Get Started, Quick Start and Installation pages, so these propagate to four pages.

| Component | Before | After | Reason |
|---|---|---|---|
| Composer | 2.7 / 2.9.3 | **2.10.2** | Earlier 2.x releases carry known security vulnerabilities; the version feed pins 2.10.2 for every 3.x release |
| MariaDB | 10.6 / 11.4 | **11.4 / 12.3** | 10.6 reached EOL 2026-07-06; 12.3 is the current LTS (EOL 2029-06-12) |
| MySQL | 8.0 / 8.4 | **8.4** / 8.4 | 8.0 reached EOL April 2026; 8.4 is the LTS the feed pins for 3.x |
| RabbitMQ | 3.13 / 4.1 | **4.0** / 4.1 | 3.13 is EOL; 3.x ships 4.1 |
| Redis | 7.0 / 7.2 | **7.2 / 8.0** | 7.0 is EOL |

### On MariaDB — please sanity-check this one

The upstream version feed carries **no MariaDB entry for any release after 1.0.x** (it pins `mysql:8.4`), and neither `mageos-magento2` nor `generate-mirror-repo-js` declares a database server version at all:

| Source | MariaDB for 3.2 |
|---|---|
| `github-actions` version feed | Pins `mysql:8.4`; the only `mariadb:10.6` belongs to the **1.0.x** line |
| `mageos-magento2` 3.2.0 `composer.json` | PHP + extensions only |
| `generate-mirror-repo-js` | No DB-server version anywhere in `resource/history` |

So these MariaDB numbers are **maintained by this site rather than derived upstream** — which is likely why they sat at 10.6/11.4 unnoticed. The 12.3 support was confirmed by the team. Flagging it explicitly so a reviewer knows this value is not echoing a source.

## System requirements page

- **Show PHP 8.4 alongside 8.3 and 8.5.** Mage-OS 3.2.0 declares `~8.3.0||~8.4.0||~8.5.0` and upstream CI builds against 8.4, but 8.4 was absent from the page entirely. Sourced from the version feed via a new `phpDisplay` value on the latest specs, so it tracks upstream automatically rather than becoming a new hardcoded value.
- **Add `ext-pcntl`**, which 3.2.0 requires but the page omitted.
- **Elasticsearch minimum fallback 7.17 → 8.x.** 3.2.0 only ships `module-elasticsearch-8`.
- **Split the OS table into Min Version / Recommended columns.** The minimums were still accurate (Ubuntu 22.04, Debian 12, Rocky/Alma 9 are all in support), but the "Recommended" badge sat on Ubuntu 22.04 rather than the current 24.04 LTS.
- **macOS development baseline 13 → 14.** Ventura is out of Apple security support.
- **Fix the Percona row**, which read its recommended value from `mysql.minimum` and so rendered "8.0 / 8.0".

Also renders the supported PHP range as "8.3 - 8.5" rather than "8.3 **or** 8.5" on the Get Started and Quick Start pages, which implied 8.4 was unsupported, and refreshes two stale fallback literals in `systemSpecs.ts` (`2.3.0` → `3.2.0`, `2.4.8-p5` → `2.4.9`).

## Two judgment calls worth a second opinion

1. **Redis recommended 8.0** — the feed dropped Redis in favour of Valkey for 3.x, so there was no upstream signal to derive this from.
2. **`fileinfo` and `sockets` left in the extension list** even though 3.2.0's `composer.json` does not require them. Removing felt riskier than leaving them.

## Verification

Verified against the built HTML that all four pages render the updated values. `npm run build` passes (196 pages).

Note the CI check on this branch will be red until #80 lands — it was branched before that fix and the failure is unrelated to these contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt1jbv8urLhzCd2DitBwXp